### PR TITLE
[xwalkdriver] Bind tizenDebuggerAddress to acquire specific device

### DIFF
--- a/xwalkdriver/xwalk/adb_impl.h
+++ b/xwalkdriver/xwalk/adb_impl.h
@@ -58,6 +58,8 @@ class AdbImpl : public Adb {
                                    const std::string& app_id) OVERRIDE;
   virtual Status CheckTizenAppInstalled(const std::string& device_serial,
                                         const std::string& app_id) OVERRIDE;
+  bool IsTizenAppRunning(const std::string& device_serial,
+                         const std::string& app_id);
  private:
   Status ExecuteCommand(const std::string& command,
                         std::string* response);

--- a/xwalkdriver/xwalk_launcher.cc
+++ b/xwalkdriver/xwalk_launcher.cc
@@ -316,11 +316,17 @@ Status LaunchTizenXwalk(
     scoped_ptr<Xwalk>* xwalk) {
   Status status(kOk);
   scoped_ptr<Device> device;
-  if (capabilities.tizen_device_serial.empty()) {
+  // In real tizen device, its device serial is always same as its
+  // net address.
+  if (capabilities.tizen_device_serial.empty() && 
+      capabilities.tizen_debugger_address.host().empty()) {
     status = device_manager->AcquireDevice(&device);
-  } else {
+  } else if (!capabilities.tizen_device_serial.empty()) {
     status = device_manager->AcquireSpecificDevice(
         capabilities.tizen_device_serial, &device);
+  } else {
+    status = device_manager->AcquireSpecificDevice(
+        capabilities.tizen_debugger_address.host(), &device);
   }
 
   if(status.IsError()) {


### PR DESCRIPTION
1.Bind "tizenDebuggerAddress" of capabilities to launch specific tizen device. In the previous codes, the validation of tizenDebuggerAddress is never be checked as the QAs descirped "unused".

2.Add check the status of running tizen app before launch, kill the app if necessary because the "app_launcher" do "start" same app on same process. Although in selenium, we can get different handles of driver(like driver0 and driver1), if we continue our test by interweaving the handles, one of them will be blocked when invoking some selenium api relatived with UI debugger.

BUG=https://crosswalk-project.org/jira/browse/XWALK-3009

@iKevinHan please help to review, much thanks:)
