### PR TITLE
[xwalkdriver] Fix get_cookie() always get None

### DIFF
--- a/xwalkdriver/server/http_handler.cc
+++ b/xwalkdriver/server/http_handler.cc
@@ -300,6 +300,10 @@ HttpHandler::HttpHandler(
                      WrapToCommand("DeleteAllCookies",
                                    base::Bind(&ExecuteDeleteAllCookies))),
       CommandMapping(
+          kGet,
+          "session/:sessionId/cookie/:name",
+          WrapToCommand("GetCookie", base::Bind(&ExecuteGetCookie))),
+      CommandMapping(
           kDelete,
           "session/:sessionId/cookie/:name",
           WrapToCommand("DeleteCookie", base::Bind(&ExecuteDeleteCookie))),

--- a/xwalkdriver/window_commands.cc
+++ b/xwalkdriver/window_commands.cc
@@ -736,7 +736,6 @@ Status ExecuteScreenshot(
     scoped_ptr<base::Value>* value) {
   Status status = session->xwalk->ActivateWebView(web_view->GetId());
   if (status.IsError()){
-    //return status;
     printf("The Crosswalk WebView Activate Status is \"%s\"\n",
                                            status.message().c_str());
   }
@@ -747,6 +746,30 @@ Status ExecuteScreenshot(
 
   value->reset(new base::StringValue(screenshot));
   return Status(kOk);
+}
+
+Status ExecuteGetCookie(
+    Session* session,
+    WebView* web_view,
+    const base::DictionaryValue& params,
+    scoped_ptr<base::Value>* value) {
+  std::string name;
+  if (!params.GetString("name", &name))
+    return Status(kUnknownError, "missing 'name'");
+  std::list<Cookie> cookies;
+  Status status = GetVisibleCookies(web_view, &cookies);
+  if (status.IsError())
+    return status;
+
+  for (std::list<Cookie>::const_iterator it = cookies.begin();
+       it != cookies.end(); ++it) {
+    if (name.compare(it->name) == 0u) {
+      value->reset(CreateDictionaryFrom(*it));
+      return Status(kOk);
+    }
+  }
+  return Status(kUnknownError,
+      "desired cookie: " + name + " doesn't exist.");
 }
 
 Status ExecuteGetCookies(

--- a/xwalkdriver/window_commands.h
+++ b/xwalkdriver/window_commands.h
@@ -248,6 +248,13 @@ Status ExecuteScreenshot(
     const base::DictionaryValue& params,
     scoped_ptr<base::Value>* value);
 
+// Retrieve specific cookie visible to the current page by name.
+Status ExecuteGetCookie(
+    Session* session,
+    WebView* web_view,
+    const base::DictionaryValue& params,
+    scoped_ptr<base::Value>* value);
+
 // Retrieve all cookies visible to the current page.
 Status ExecuteGetCookies(
     Session* session,


### PR DESCRIPTION
Fulfill that xwalkdriver can aqcuire specific cookie content by name of cookie through driver.get_cookie('name') on selenium side.

At present, Site "https://code.google.com/p/selenium/wiki/JsonWireProtocol" does not include "GET /session/:sessionId/cookie/:name", however selenium' remote webdriver does provide this api. So I think we should sync them both.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2437
