### PR TITLE
[xwalkdriver] Fix Tizen devices not onlines errors

### DIFF
--- a/xwalkdriver/xwalk/adb_impl.cc
+++ b/xwalkdriver/xwalk/adb_impl.cc
@@ -89,7 +89,7 @@ Status AdbImpl::GetDevices(std::vector<std::string>* devices) {
   while (lines.GetNext()) {
     std::vector<std::string> fields;
     base::SplitStringAlongWhitespace(lines.token(), &fields);
-    if ((fields.size() == 3 || fields.size() == 2) && fields[1] == "device") {
+    if (fields.size() == 2 && fields[1] == "device") {
       devices->push_back(fields[0]);
     }
   }


### PR DESCRIPTION
Should not determine the online state by size of field (whitespace counts) in SdbImpl::GetDevice 
methods since we can't not assume what the target hostname outcome looks like.
>On older Tizen devices, when invoke "sdb devices" on the host:
    >>>>>> List of devices attached
    >>>>>> 10.238.158.xx:9333    device   Unknown
>On later ones, it looks like:
    >>>>>> List of devices attached
    >>>>>> 10.238.158.xx:9333    device   Tizen IVI 3.0